### PR TITLE
chore(feeds): feed_items table to store feed items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,11 @@ migrate:
 	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20221108_add_expires_at_to_posts.sql
 	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20221112_add_feeds_space.sql
 	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20230310_add_aliases_table.sql
+	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20230326_add_feed_items.sql
 .PHONY: migrate
 
 latest:
-	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20230310_add_aliases_table.sql
+	$(DOCKER_CMD) exec -i $(DB_CONTAINER) psql -U $(PGUSER) -d $(PGDATABASE) < ./sql/migrations/20230326_add_feed_items.sql
 .PHONY: latest
 
 psql:

--- a/db/db.go
+++ b/db/db.go
@@ -48,6 +48,31 @@ func (p *PostData) Scan(value interface{}) error {
 	return json.Unmarshal(b, &p)
 }
 
+type FeedItemData struct {
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Content     string     `json:"content"`
+	Link        string     `json:"link"`
+	PublishedAt *time.Time `json:"published_at"`
+}
+
+// Make the Attrs struct implement the driver.Valuer interface. This method
+// simply returns the JSON-encoded representation of the struct.
+func (p FeedItemData) Value() (driver.Value, error) {
+	return json.Marshal(p)
+}
+
+// Make the Attrs struct implement the sql.Scanner interface. This method
+// simply decodes a JSON-encoded value into the struct fields.
+func (p *FeedItemData) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, &p)
+}
+
 type Post struct {
 	ID          string     `json:"id"`
 	UserID      string     `json:"user_id"`
@@ -95,6 +120,14 @@ type PostAnalytics struct {
 type Pager struct {
 	Num  int
 	Page int
+}
+
+type FeedItem struct {
+	ID        string
+	PostID    string
+	GUID      string
+	Data      FeedItemData
+	CreatedAt *time.Time
 }
 
 type ErrMultiplePublicKeys struct{}
@@ -162,6 +195,9 @@ type DB interface {
 
 	HasFeatureForUser(userID string, feature string) bool
 	FindTotalSizeForUser(userID string) (int, error)
+
+	InsertFeedItems(postID string, items []*FeedItem) error
+	FindFeedItemsByPostID(postID string) ([]*FeedItem, error)
 
 	Close() error
 }

--- a/sql/migrations/20230326_add_feed_items.sql
+++ b/sql/migrations/20230326_add_feed_items.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS feed_items (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  post_id uuid NOT NULL,
+  guid character varying (1000) NOT NULL,
+  data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp without time zone NOT NULL DEFAULT NOW(),
+  CONSTRAINT feed_items_pkey PRIMARY KEY (id),
+  CONSTRAINT fk_feed_items_posts
+    FOREIGN KEY(post_id)
+  REFERENCES posts(id)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE
+);


### PR DESCRIPTION
Some RSS feeds are technically invalid but still want to be fetched.  In these cases we want to make sure we can still fetch them and properly handle when the feed item does not contain correct tags for dates.

Previously we used `published` and internally `last_digest` to determine if a feed has already been sent to the user.  Well some feed items do not contain `published` so we would always send the feed item to the user in their email digest.

Now we are storing the feed items we have fetched in a separate table along with some of its metadata in order to properly mark a feed item as "already sent."  Now it doesn't matter if the feed item has the correct tags or not, we will try to fetch the items, send them to the user, and them mark them as already sent.