### PR TITLE
Updates for macOS build compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ This repo hosts the following pico services:
 
 - `golang` >= 1.19
 - `direnv` to load environment vars
+- `webp` macOS dependency
+  - can be installed with `brew install webp`
 
 ```bash
 cp ./.env.example .env
+```
+
+Initialize local env variables using direnv
+
+```bash
+echo dotenv > .envrc && direnv allow
 ```
 
 Boot up database
@@ -46,13 +54,14 @@ make build
 
 All services are built inside the `./build` folder.
 
-If you want to start prose:
+If you want to start prose execute these binaries from the project root directory:
 
 ```bash
 ./build/prose-web
 # in a separate terminal
 ./build/prose-ssh
 ```
+
 
 ## deployment
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/gliderlabs/ssh v0.3.5
 	github.com/gorilla/feeds v1.1.1
-	github.com/kolesa-team/go-webp v1.0.2
+	github.com/kolesa-team/go-webp v1.0.4
 	github.com/lib/pq v1.10.7
 	github.com/matryer/is v1.4.0
 	github.com/microcosm-cc/bluemonday v1.0.21

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/klauspost/cpuid/v2 v2.2.2 h1:xPMwiykqNK9VK0NYC3+jTMYv9I6Vl3YdjZgPZKG3
 github.com/klauspost/cpuid/v2 v2.2.2/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kolesa-team/go-webp v1.0.2 h1:XCrWqxI7tNOI3dr0YufD9TUb+54vBDogg9KsHH7q5Lc=
 github.com/kolesa-team/go-webp v1.0.2/go.mod h1:oMvdivD6K+Q5qIIkVC2w4k2ZUnI1H+MyP7inwgWq9aA=
+github.com/kolesa-team/go-webp v1.0.4 h1:wQvU4PLG/X7RS0vAeyhiivhLRoxfLVRlDq4I3frdxIQ=
+github.com/kolesa-team/go-webp v1.0.4/go.mod h1:oMvdivD6K+Q5qIIkVC2w4k2ZUnI1H+MyP7inwgWq9aA=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
I'm just getting pico building and running locally on an m1 mac and ran into a couple issues that this resolves.

1) Upgraded go package dependency who's newer version has a fix for building on mac: https://github.com/kolesa-team/go-webp/pull/22
2) Referenced a system package dependency in the readme for mac (webp).

I also added a couple other minor additions to the readme that aren't strictly necessary.