### PR TITLE
Fix for the 'draft/hidden' value not updating

### DIFF
--- a/db/postgres/storage.go
+++ b/db/postgres/storage.go
@@ -232,7 +232,7 @@ const (
 	sqlUpdatePost = `
 	UPDATE posts
 	SET slug = $1, title = $2, text = $3, description = $4, updated_at = $5, publish_at = $6,
-		file_size = $7, shasum = $8, data = $9
+		file_size = $7, shasum = $8, data = $9, hidden = $11
 	WHERE id = $10`
 	sqlUpdateUserName = `UPDATE app_users SET name = $1 WHERE id = $2`
 	sqlIncrementViews = `UPDATE posts SET views = views + 1 WHERE id = $1 RETURNING views`
@@ -714,6 +714,7 @@ func (me *PsqlDB) UpdatePost(post *db.Post) (*db.Post, error) {
 		post.Shasum,
 		post.Data,
 		post.ID,
+		post.Hidden,
 	)
 	if err != nil {
 		return nil, err

--- a/filehandlers/imgs/img.go
+++ b/filehandlers/imgs/img.go
@@ -208,6 +208,7 @@ func (h *UploadImgHandler) writeImg(s ssh.Session, data *PostMetaData) error {
 			Shasum:      data.Shasum,
 			Text:        data.Text,
 			Title:       data.Title,
+			Hidden:      data.Hidden,
 		}
 		_, err = h.DBPool.UpdatePost(&updatePost)
 		if err != nil {

--- a/filehandlers/post_handler.go
+++ b/filehandlers/post_handler.go
@@ -305,6 +305,7 @@ func (h *ScpUploadHandler) Write(s ssh.Session, entry *utils.FileEntry) (string,
 			Shasum:      metadata.Shasum,
 			Text:        metadata.Text,
 			Title:       metadata.Title,
+			Hidden:      metadata.Hidden,
 		}
 		_, err = h.DBPool.UpdatePost(&updatePost)
 		if err != nil {


### PR DESCRIPTION
This change ensures the 'hidden' value gets updated when the draft attribute is modified.

I tested this running prose ssh locally and scp'ing various files modifying the draft back and forth to ensure it updated. Also tried with new files using draft and not using draft, adding draft after the fact, etc.

I'm new to golang and this codebase, so it's very possible I missed something with this.