### PR TITLE
feat: cannot link to a project that is also a link

### DIFF
--- a/cmd/pgs/ssh/main.go
+++ b/cmd/pgs/ssh/main.go
@@ -38,7 +38,7 @@ func createRouter(cfg *shared.ConfigSite, handler *uploadassets.UploadAssetHandl
 		return []wish.Middleware{
 			pipe.Middleware(handler, ""),
 			list.Middleware(handler),
-			pgs.WishMiddleware(handler.DBPool, handler.Storage, handler.Cfg.Logger),
+			pgs.WishMiddleware(handler),
 			scp.Middleware(handler),
 			wishrsync.Middleware(handler),
 			auth.Middleware(handler),

--- a/db/db.go
+++ b/db/db.go
@@ -207,7 +207,7 @@ type DB interface {
 	FindFeedItemsByPostID(postID string) ([]*FeedItem, error)
 
 	InsertProject(userID, name, projectDir string) (string, error)
-	UpdateProject(projectID, projectDir string) error
+	LinkToProject(userID, projectID, projectDir string) error
 	RemoveProject(projectID string) error
 	FindProjectByName(userID, name string) (*Project, error)
 	FindProjectsByUser(userID string) ([]*Project, error)

--- a/filehandlers/imgs/handler.go
+++ b/filehandlers/imgs/handler.go
@@ -19,15 +19,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var KB = 1024
-var MB = KB * 1024
-var GB = MB * 1024
-var maxSize = 1 * GB
-var maxImgSize = 10 * MB
-
-func bytesToGB(size int) float32 {
-	return (((float32(size) / 1024) / 1024) / 1024)
-}
+var maxSize = 1 * shared.GB
+var maxImgSize = 10 * shared.MB
 
 type ctxUserKey struct{}
 
@@ -274,8 +267,8 @@ func (h *UploadImgHandler) Write(s ssh.Session, entry *utils.FileEntry) (string,
 	str := fmt.Sprintf(
 		"%s (space: %.2f/%.2fGB, %.2f%%)",
 		url,
-		bytesToGB(totalFileSize),
-		bytesToGB(maxSize),
+		shared.BytesToGB(totalFileSize),
+		shared.BytesToGB(maxSize),
 		(float32(totalFileSize)/float32(maxSize))*100,
 	)
 	return str, nil

--- a/filehandlers/imgs/img.go
+++ b/filehandlers/imgs/img.go
@@ -68,7 +68,7 @@ func (h *UploadImgHandler) metaImg(data *PostMetaData) error {
 	opt := shared.NewImgOptimizer(h.Cfg.Logger, "")
 	// for small images we want to preserve quality
 	// since it can have a dramatic effect
-	if data.FileSize < 3*MB {
+	if data.FileSize < 3*shared.MB {
 		opt.Quality = 100
 		opt.Lossless = true
 	} else {

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -7,24 +7,8 @@ import (
 	"github.com/picosh/pico/wish/cms/config"
 )
 
-type ImgsLinkify struct {
-	Cfg          *shared.ConfigSite
-	Username     string
-	OnSubdomain  bool
-	WithUsername bool
-}
-
-func NewImgsLinkify(username string) *ImgsLinkify {
-	cfg := NewConfigSite()
-	return &ImgsLinkify{
-		Cfg:      cfg,
-		Username: username,
-	}
-}
-
-func (i *ImgsLinkify) Create(fname string) string {
-	return i.Cfg.ImgFullURL(i.Username, fname)
-}
+var maxSize = 1 * shared.GB
+var maxAssetSize = 50 * shared.MB
 
 func NewConfigSite() *shared.ConfigSite {
 	debug := shared.GetEnv("PGS_DEBUG", "0")
@@ -84,6 +68,8 @@ func NewConfigSite() *shared.ConfigSite {
 				".json",
 				".md",
 			},
+			MaxSize:       maxSize,
+			MaxAssetSize:  maxAssetSize,
 			Logger:        shared.CreateLogger(),
 			AllowRegister: allowRegister == "1",
 		},

--- a/pgs/html/marketing.page.tmpl
+++ b/pgs/html/marketing.page.tmpl
@@ -38,7 +38,7 @@
     <h2 class="text-lg font-bold">Examples</h2>
     <ul>
       <li>The site you are reading right now</li>
-      <li><a href="https://git.erock.sh">git web viewer</a></li>
+      <li><a href="https://git.erock.io">git web viewer</a></li>
     </ul>
   </section>
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -21,6 +21,10 @@ import (
 
 var fnameRe = regexp.MustCompile(`[-_]+`)
 
+var KB = 1024
+var MB = KB * 1024
+var GB = MB * 1024
+
 func FilenameToTitle(filename string, title string) string {
 	if filename != title {
 		return title
@@ -161,4 +165,8 @@ func GetMimeType(fpath string) string {
 	}
 
 	return "text/plain"
+}
+
+func BytesToGB(size int) float32 {
+	return (((float32(size) / 1024) / 1024) / 1024)
 }

--- a/wish/cms/config/config.go
+++ b/wish/cms/config/config.go
@@ -26,6 +26,8 @@ type ConfigCms struct {
 	HiddenPosts   []string
 	Logger        *zap.SugaredLogger
 	AllowRegister bool
+	MaxSize       int
+	MaxAssetSize  int
 }
 
 func NewConfigCms() *ConfigCms {


### PR DESCRIPTION
A project linked to another project which is also linked to a project is forbidden.  CI/CD Example:
        - ProjectProd links to ProjectStaging
        - ProjectStaging links to ProjectMain
        - We merge `main` and trigger a deploy which uploads to ProjectMain
        - All three get updated immediately
This scenario was not the intent of our CI/CD.  What we actually wanted was to create a snapshot of ProjectMain and have ProjectStaging link to the snapshot, but that's not the intended design of pgs.

So we want to close that gap here.