### PR TITLE
Updated dependencies required in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ This repo hosts the following pico services:
 
 ## development
 
-- `golang` >= 1.19
+- `golang` >= 1.21.0
 - `direnv` to load environment vars
-- `webp` macOS dependency
-  - can be installed with `brew install webp`
+- `webp` package dependency
+  - on mac can be installed with `brew install webp`
+  - on ubuntu can be installed with `sudo apt install libwebp-dev`
 
 ```bash
 cp ./.env.example .env


### PR DESCRIPTION
As of todays date, I was working through getting the latest pico running in Ubuntu 22. I had go 1.19.1 installed and ran into two dependeny issues running `make build`. This updates the readme to account for the latest requiements.

![image](https://github.com/picosh/pico/assets/14192678/592e8abb-66ae-4cfc-9d1f-7a79c8a82a99)

![image](https://github.com/picosh/pico/assets/14192678/84a95250-0682-4e06-a467-1778b797eda6)
