### PR TITLE
refactor(imgs): dont bring libwebp into every service

### DIFF
--- a/cmd/scripts/webp/webp.go
+++ b/cmd/scripts/webp/webp.go
@@ -50,9 +50,9 @@ func main() {
 		}
 		defer reader.Close()
 
-		opt := shared.NewImgOptimizer(cfg.Logger, "")
+		opt := imgs.NewImgOptimizer(cfg.Logger, "")
 		contents := &bytes.Buffer{}
-		img, err := shared.GetImageForOptimization(reader, post.MimeType)
+		img, err := imgs.GetImageForOptimization(reader, post.MimeType)
 		if err != nil {
 			cfg.Logger.Error(err)
 			continue

--- a/filehandlers/imgs/client.go
+++ b/filehandlers/imgs/client.go
@@ -1,0 +1,39 @@
+package uploadimgs
+
+import (
+	"github.com/charmbracelet/ssh"
+	"github.com/picosh/pico/db"
+	"github.com/picosh/pico/imgs"
+	"github.com/picosh/pico/shared"
+	"github.com/picosh/pico/shared/storage"
+	"github.com/picosh/pico/wish/send/utils"
+)
+
+type ImgsAPI struct {
+	Cfg *shared.ConfigSite
+	Db  db.DB
+	St  storage.ObjectStorage
+}
+
+func NewImgsAPI(dbpool db.DB, st storage.ObjectStorage) *ImgsAPI {
+	cfg := imgs.NewConfigSite()
+	return &ImgsAPI{
+		Cfg: cfg,
+		Db:  dbpool,
+		St:  st,
+	}
+}
+
+func (img *ImgsAPI) HasAccess(userID string) bool {
+	return img.Db.HasFeatureForUser(userID, "imgs")
+}
+
+func (img *ImgsAPI) Upload(s ssh.Session, file *utils.FileEntry) (string, error) {
+	handler := NewUploadImgHandler(img.Db, img.Cfg, img.St)
+	err := handler.Validate(s)
+	if err != nil {
+		return "", err
+	}
+
+	return handler.Write(s, file)
+}

--- a/filehandlers/imgs/img.go
+++ b/filehandlers/imgs/img.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/ssh"
 	"github.com/picosh/pico/db"
+	"github.com/picosh/pico/imgs"
 	"github.com/picosh/pico/shared"
 	"github.com/picosh/pico/wish/send/utils"
 )
@@ -67,7 +68,7 @@ func (h *UploadImgHandler) metaImg(data *PostMetaData) error {
 		return err
 	}
 
-	opt := shared.NewImgOptimizer(h.Cfg.Logger, "")
+	opt := imgs.NewImgOptimizer(h.Cfg.Logger, "")
 	// for small images we want to preserve quality
 	// since it can have a dramatic effect
 	if data.FileSize < 3*shared.MB {
@@ -81,9 +82,9 @@ func (h *UploadImgHandler) metaImg(data *PostMetaData) error {
 	var webpReader *bytes.Reader
 	contents := &bytes.Buffer{}
 
-	img, err := shared.GetImageForOptimization(tee, data.MimeType)
+	img, err := imgs.GetImageForOptimization(tee, data.MimeType)
 	finalName := shared.SanitizeFileExt(data.Filename)
-	if errors.Is(err, shared.ErrAlreadyWebPError) {
+	if errors.Is(err, imgs.ErrAlreadyWebPError) {
 		h.Cfg.Logger.Infof("(%s) is already webp, skipping encoding", data.Filename)
 		finalName = fmt.Sprintf("%s.webp", finalName)
 		webpReader = tee

--- a/filehandlers/post_handler.go
+++ b/filehandlers/post_handler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/charmbracelet/ssh"
 	"github.com/picosh/pico/db"
-	"github.com/picosh/pico/imgs"
+	uploadimgs "github.com/picosh/pico/filehandlers/imgs"
 	"github.com/picosh/pico/shared"
 	"github.com/picosh/pico/shared/storage"
 	"github.com/picosh/pico/wish/cms/util"
@@ -48,11 +48,11 @@ type ScpUploadHandler struct {
 	DBPool    db.DB
 	Cfg       *shared.ConfigSite
 	Hooks     ScpFileHooks
-	ImgClient *imgs.ImgsAPI
+	ImgClient *uploadimgs.ImgsAPI
 }
 
 func NewScpPostHandler(dbpool db.DB, cfg *shared.ConfigSite, hooks ScpFileHooks, st storage.ObjectStorage) *ScpUploadHandler {
-	client := imgs.NewImgsAPI(dbpool, st)
+	client := uploadimgs.NewImgsAPI(dbpool, st)
 
 	return &ScpUploadHandler{
 		DBPool:    dbpool,

--- a/imgs/api.go
+++ b/imgs/api.go
@@ -192,7 +192,7 @@ type ImgHandler struct {
 	Storage   storage.ObjectStorage
 	Logger    *zap.SugaredLogger
 	Cache     *gocache.Cache
-	Img       *shared.ImgOptimizer
+	Img       *ImgOptimizer
 	// We should try to use the optimized image if it's available
 	// not all images are optimized so this flag isn't enough
 	// because we also need to check the mime type
@@ -203,7 +203,7 @@ type ImgResizer struct {
 	Key      string
 	contents utils.ReaderAtCloser
 	writer   io.Writer
-	Img      *shared.ImgOptimizer
+	Img      *ImgOptimizer
 	Cache    *gocache.Cache
 }
 
@@ -277,7 +277,7 @@ func imgHandler(w http.ResponseWriter, h *ImgHandler) {
 
 	contentType := post.MimeType
 	fname := post.Filename
-	isWebOptimized := shared.IsWebOptimized(contentType)
+	isWebOptimized := IsWebOptimized(contentType)
 
 	if h.UseOptimized && isWebOptimized {
 		contentType = "image/webp"
@@ -357,7 +357,7 @@ func imgRequestOriginal(w http.ResponseWriter, r *http.Request) {
 		Storage:      st,
 		Logger:       logger,
 		Cache:        cache,
-		Img:          shared.NewImgOptimizer(logger, ""),
+		Img:          NewImgOptimizer(logger, ""),
 		UseOptimized: false,
 	})
 }
@@ -395,7 +395,7 @@ func imgRequest(w http.ResponseWriter, r *http.Request) {
 		Storage:      st,
 		Logger:       logger,
 		Cache:        cache,
-		Img:          shared.NewImgOptimizer(logger, dimes),
+		Img:          NewImgOptimizer(logger, dimes),
 		UseOptimized: true,
 	})
 }

--- a/imgs/client.go
+++ b/imgs/client.go
@@ -1,44 +1,10 @@
 package imgs
 
 import (
-	"github.com/charmbracelet/ssh"
-	"github.com/picosh/pico/db"
-	uploadimgs "github.com/picosh/pico/filehandlers/imgs"
-	"github.com/picosh/pico/shared"
-	"github.com/picosh/pico/shared/storage"
 	"github.com/picosh/pico/wish/send/utils"
 )
 
 type IImgsAPI interface {
 	HasAccess(userID string) bool
 	Upload(file *utils.FileEntry) (string, error)
-}
-
-type ImgsAPI struct {
-	Cfg *shared.ConfigSite
-	Db  db.DB
-	St  storage.ObjectStorage
-}
-
-func NewImgsAPI(dbpool db.DB, st storage.ObjectStorage) *ImgsAPI {
-	cfg := NewConfigSite()
-	return &ImgsAPI{
-		Cfg: cfg,
-		Db:  dbpool,
-		St:  st,
-	}
-}
-
-func (img *ImgsAPI) HasAccess(userID string) bool {
-	return img.Db.HasFeatureForUser(userID, "imgs")
-}
-
-func (img *ImgsAPI) Upload(s ssh.Session, file *utils.FileEntry) (string, error) {
-	handler := uploadimgs.NewUploadImgHandler(img.Db, img.Cfg, img.St)
-	err := handler.Validate(s)
-	if err != nil {
-		return "", err
-	}
-
-	return handler.Write(s, file)
 }

--- a/imgs/optimizer.go
+++ b/imgs/optimizer.go
@@ -1,7 +1,6 @@
-package shared
+package imgs
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"image"
@@ -67,21 +66,6 @@ func IsWebOptimized(mimeType string) bool {
 	}
 
 	return false
-}
-
-func CreateImgURL(linkify Linkify) func([]byte) []byte {
-	return func(url []byte) []byte {
-		if url[0] == '/' {
-			name := SanitizeFileExt(string(url))
-			nextURL := linkify.Create(name)
-			return []byte(nextURL)
-		} else if bytes.HasPrefix(url, []byte{'.', '/'}) {
-			name := SanitizeFileExt(string(url[1:]))
-			nextURL := linkify.Create(name)
-			return []byte(nextURL)
-		}
-		return url
-	}
 }
 
 func GetRatio(dimes string) (*Ratio, error) {

--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -205,6 +205,21 @@ func (r *ImgRender) renderImage(w util.BufWriter, source []byte, node ast.Node, 
 	return ast.WalkSkipChildren, nil
 }
 
+func CreateImgURL(linkify Linkify) func([]byte) []byte {
+	return func(url []byte) []byte {
+		if url[0] == '/' {
+			name := SanitizeFileExt(string(url))
+			nextURL := linkify.Create(name)
+			return []byte(nextURL)
+		} else if bytes.HasPrefix(url, []byte{'.', '/'}) {
+			name := SanitizeFileExt(string(url[1:]))
+			nextURL := linkify.Create(name)
+			return []byte(nextURL)
+		}
+		return url
+	}
+}
+
 func ParseText(text string, linkify Linkify) (*ParsedText, error) {
 	parsed := ParsedText{
 		MetaData: &MetaData{


### PR DESCRIPTION
Most of our libwebp related code lived inside the `shared` package.  This is problematic since every service imports that package, thereby requiring libwebp for every service.

Now references to libwebp live solely inside `imgs` library.

Unfortunately, all of our post-based SSH services import `imgs` so they still have the requirement.