### PR TITLE
feat: support more imgproxy options

### DIFF
--- a/pgs/api.go
+++ b/pgs/api.go
@@ -370,7 +370,7 @@ func ImgAssetRequest(w http.ResponseWriter, r *http.Request) {
 	logger := shared.GetLogger(r)
 	fname, _ := url.PathUnescape(shared.GetField(r, 0))
 	imgOpts, _ := url.PathUnescape(shared.GetField(r, 1))
-	opts, err := storage.UriToImgProcessOpts("/" + imgOpts)
+	opts, err := storage.UriToImgProcessOpts(imgOpts)
 	if err != nil {
 		errMsg := fmt.Sprintf("error processing img options: %s", err.Error())
 		logger.Infof(errMsg)
@@ -424,7 +424,7 @@ func StartApiServer() {
 	}
 	subdomainRoutes := []shared.Route{
 		shared.NewRoute("GET", "/", AssetRequest),
-		shared.NewRoute("GET", "/([^/]+.(?:jpg|jpeg|png|gif|webp|svg))/(.+)", ImgAssetRequest),
+		shared.NewRoute("GET", "(/.+.(?:jpg|jpeg|png|gif|webp|svg))(/.+)", ImgAssetRequest),
 		shared.NewRoute("GET", "/(.+)", AssetRequest),
 	}
 

--- a/pgs/api.go
+++ b/pgs/api.go
@@ -366,6 +366,20 @@ func ServeAsset(fname string, opts *storage.ImgProcessOpts, fromImgs bool, w htt
 	asset.handle(w)
 }
 
+func ImgAssetRequest(w http.ResponseWriter, r *http.Request) {
+	logger := shared.GetLogger(r)
+	fname, _ := url.PathUnescape(shared.GetField(r, 0))
+	imgOpts, _ := url.PathUnescape(shared.GetField(r, 1))
+	opts, err := storage.UriToImgProcessOpts("/" + imgOpts)
+	if err != nil {
+		errMsg := fmt.Sprintf("error processing img options: %s", err.Error())
+		logger.Infof(errMsg)
+		http.Error(w, errMsg, http.StatusUnprocessableEntity)
+	}
+
+	ServeAsset(fname, opts, false, w, r)
+}
+
 func AssetRequest(w http.ResponseWriter, r *http.Request) {
 	fname, _ := url.PathUnescape(shared.GetField(r, 0))
 	ServeAsset(fname, nil, false, w, r)
@@ -410,6 +424,7 @@ func StartApiServer() {
 	}
 	subdomainRoutes := []shared.Route{
 		shared.NewRoute("GET", "/", AssetRequest),
+		shared.NewRoute("GET", "/([^/]+.(?:jpg|jpeg|png|gif|webp|svg))/(.+)", ImgAssetRequest),
 		shared.NewRoute("GET", "/(.+)", AssetRequest),
 	}
 

--- a/prose/api.go
+++ b/prose/api.go
@@ -827,8 +827,8 @@ func createMainRoutes(staticRoutes []shared.Route) []shared.Route {
 		shared.NewRoute("GET", "/([^/]+)/feed.xml", rssBlogHandler),
 		shared.NewRoute("GET", "/([^/]+)/_styles.css", blogStyleHandler),
 		shared.NewRoute("GET", "/raw/([^/]+)/(.+)", postRawHandler),
-		shared.NewRoute("GET", "/([^/]+)/(.+)/([a-z0-9]+)", imgs.ImgRequest),
-		shared.NewRoute("GET", "/([^/]+)/(.+).(jpg|jpeg|png|gif|webp|svg)", imgs.ImgRequest),
+		shared.NewRoute("GET", "/([^/]+)/(.+)/(.+)", imgs.ImgRequest),
+		shared.NewRoute("GET", "/([^/]+)/(.+).(?:jpg|jpeg|png|gif|webp|svg)$", imgs.ImgRequest),
 		shared.NewRoute("GET", "/([^/]+)/i", imgs.ImgsListHandler),
 		shared.NewRoute("GET", "/([^/]+)/(.+)", postHandler),
 	)
@@ -856,8 +856,8 @@ func createSubdomainRoutes(staticRoutes []shared.Route) []shared.Route {
 	routes = append(
 		routes,
 		shared.NewRoute("GET", "/raw/(.+)", postRawHandler),
-		shared.NewRoute("GET", "/(.+)/([a-z0-9]+)", imgs.ImgRequest),
-		shared.NewRoute("GET", "/(.+).(jpg|jpeg|png|gif|webp|svg)", imgs.ImgRequest),
+		shared.NewRoute("GET", "/([^/]+)/(.+)", imgs.ImgRequest),
+		shared.NewRoute("GET", "/(.+).(?:jpg|jpeg|png|gif|webp|svg)$", imgs.ImgRequest),
 		shared.NewRoute("GET", "/i", imgs.ImgsListHandler),
 		shared.NewRoute("GET", "/(.+)", postHandler),
 	)

--- a/shared/storage/proxy_test.go
+++ b/shared/storage/proxy_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type Fixture struct {
+	name   string
+	input  string
+	expect *ImgProcessOpts
+}
+
+func TestUriToImgProcessOpts(t *testing.T) {
+	fixtures := []Fixture{
+		{
+			name:  "imgs_api_height",
+			input: "/x500",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  0,
+					Height: 500,
+				},
+			},
+		},
+		{
+			name:  "imgs_api_width",
+			input: "/500x",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  500,
+					Height: 0,
+				},
+			},
+		},
+		{
+			name:  "imgs_api_both",
+			input: "/500x600",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  500,
+					Height: 600,
+				},
+			},
+		},
+		{
+			name:  "imgproxy_height",
+			input: "/s::500",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  0,
+					Height: 500,
+				},
+			},
+		},
+		{
+			name:  "imgproxy_width",
+			input: "/s:500",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  500,
+					Height: 0,
+				},
+			},
+		},
+		{
+			name:  "imgproxy_both",
+			input: "/s:500:600",
+			expect: &ImgProcessOpts{
+				Ratio: &Ratio{
+					Width:  500,
+					Height: 600,
+				},
+			},
+		},
+		{
+			name:  "imgproxy_quality",
+			input: "/q:80",
+			expect: &ImgProcessOpts{
+				Quality: 80,
+			},
+		},
+		{
+			name:  "imgproxy_rotate",
+			input: "/rt:90",
+			expect: &ImgProcessOpts{
+				Rotate: 90,
+			},
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			results, err := UriToImgProcessOpts(fixture.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if cmp.Equal(results, fixture.expect) == false {
+				t.Fatalf(cmp.Diff(fixture.expect, results))
+			}
+		})
+	}
+}

--- a/shared/storage/ratio.go
+++ b/shared/storage/ratio.go
@@ -16,6 +16,11 @@ func GetRatio(dimes string) (*Ratio, error) {
 		return nil, nil
 	}
 
+	// bail if we detect imgproxy options
+	if strings.Contains(dimes, ":") {
+		return nil, nil
+	}
+
 	// dimes = x250 -- width is auto scaled and height is 250
 	if strings.HasPrefix(dimes, "x") {
 		height, err := strconv.Atoi(dimes[1:])


### PR DESCRIPTION
New options in any combinations:

- `/s:w:h`
- `/q:1-100`
- `/rt:angle`

We also still support our imgs api version of sizing.