### PR TITLE
prose: infer title from first <h1> before any <p>

### DIFF
--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -216,7 +216,7 @@ func ParseText(text string) (*ParsedText, error) {
 	parsed.MetaData.Title = title
 	// 2. If an <h1> is found before a <p> or other heading is found, use that
 	if parsed.MetaData.Title == "" {
-		ast.Walk(doc, func (n ast.Node, entering bool) (ast.WalkStatus, error) {
+		err = ast.Walk(doc, func (n ast.Node, entering bool) (ast.WalkStatus, error) {
 			if n.Kind() == ast.KindHeading {
 				if h := n.(*ast.Heading); h.Level == 1 {
 					parsed.MetaData.Title = string(h.Text(btext))
@@ -230,6 +230,9 @@ func ParseText(text string) (*ParsedText, error) {
 			}
 			return ast.WalkContinue, nil
 		})
+		if err != nil {
+			panic(err) // unreachable
+		}
 	}
 	// 3. else, set it to nothing (slug should get used later down the line)
 	// this is implicit since it's already ""

--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -226,6 +226,8 @@ func ParseText(text string) (*ParsedText, error) {
 			if n.Kind() == ast.KindHeading {
 				if h := n.(*ast.Heading); h.Level == 1 {
 					parsed.MetaData.Title = string(h.Text(btext))
+					p := h.Parent()
+					p.RemoveChild(p, n)
 				}
 				return ast.WalkStop, nil
 			}

--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -232,7 +232,7 @@ func ParseText(text string) (*ParsedText, error) {
 			if ast.IsParagraph(n) {
 				return ast.WalkStop, nil
 			}
-			return ast.WalkStop, nil
+			return ast.WalkContinue, nil
 		})
 	}
 	// 3. else, set it to nothing (slug should get used later down the line)

--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -216,7 +216,7 @@ func ParseText(text string) (*ParsedText, error) {
 	parsed.MetaData.Title = title
 	// 2. If an <h1> is found before a <p> or other heading is found, use that
 	if parsed.MetaData.Title == "" {
-		err = ast.Walk(doc, func (n ast.Node, entering bool) (ast.WalkStatus, error) {
+		err = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 			if n.Kind() == ast.KindHeading {
 				if h := n.(*ast.Heading); h.Level == 1 {
 					parsed.MetaData.Title = string(h.Text(btext))


### PR DESCRIPTION
This eliminates the need to use explicit title metadata for the vast majority of posts.
This still allows explicitly setting a title via the frontmatter. If neither is found, the current logic goes on.

TODO: infer first `<p>` to be description.
TODO: consider supporting hashtags.