### PR TITLE
Toc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/yuin/goldmark-meta v1.1.0
 	go.abhg.dev/goldmark/anchor v0.1.1
 	go.abhg.dev/goldmark/hashtag v0.3.1
+	go.abhg.dev/goldmark/toc v0.10.0
 	golang.org/x/crypto v0.18.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ go.abhg.dev/goldmark/anchor v0.1.1 h1:NUH3hAzhfeymRqZKOkSoFReZlEAmfXBZlbXEzpD2Qg
 go.abhg.dev/goldmark/anchor v0.1.1/go.mod h1:zYKiaHXTdugwVJRZqInVdmNGQRM3ZRJ6AGBC7xP7its=
 go.abhg.dev/goldmark/hashtag v0.3.1 h1:k0FQwEtVQ1SstIRR2fqDJ4VNYUS0AXLp869V0qHOZMg=
 go.abhg.dev/goldmark/hashtag v0.3.1/go.mod h1:rXtvxXPL7auhPMGRdG02UrXn/9LMm6PNdP5HO64zbVU=
+go.abhg.dev/goldmark/toc v0.10.0 h1:de3LrIimwtGhBMKh7aEl1c6n4XWwOdukIO5wOAMYZzg=
+go.abhg.dev/goldmark/toc v0.10.0/go.mod h1:OpH0qqRP9v/eosCV28ZeqGI78jZ8rri3C7Jh8fzEo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -361,3 +363,5 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/prose/public/main.css
+++ b/prose/public/main.css
@@ -59,6 +59,10 @@ table {
   height: auto;
 }
 
+#toc {
+  margin: 0;
+}
+
 .thumbnail-link {
   z-index: 1;
 }

--- a/shared/mdparser.go
+++ b/shared/mdparser.go
@@ -171,6 +171,20 @@ func toTags(obj interface{}) ([]string, error) {
 	return arr, nil
 }
 
+func CreateGoldmark(extenders ...goldmark.Extender) goldmark.Markdown {
+	return goldmark.New(
+		goldmark.WithExtensions(
+			extenders...,
+		),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(
+			ghtml.WithUnsafe(),
+		),
+	)
+}
+
 func ParseText(text string) (*ParsedText, error) {
 	parsed := ParsedText{
 		MetaData: &MetaData{
@@ -195,17 +209,7 @@ func ParseText(text string) (*ParsedText, error) {
 			Texter:   anchor.Text("#"),
 		},
 	}
-	md := goldmark.New(
-		goldmark.WithExtensions(
-			extenders...,
-		),
-		goldmark.WithParserOptions(
-			parser.WithAutoHeadingID(),
-		),
-		goldmark.WithRendererOptions(
-			ghtml.WithUnsafe(),
-		),
-	)
+	md := CreateGoldmark(extenders...)
 	context := parser.NewContext()
 	// we do the Parse/Render steps manually to get a chance to examine the AST
 	btext := []byte(text)
@@ -225,17 +229,7 @@ func ParseText(text string) (*ParsedText, error) {
 			TitleID:    "toc",
 			ListID:     "toc-list",
 		})
-		md = goldmark.New(
-			goldmark.WithExtensions(
-				extenders...,
-			),
-			goldmark.WithParserOptions(
-				parser.WithAutoHeadingID(),
-			),
-			goldmark.WithRendererOptions(
-				ghtml.WithUnsafe(),
-			),
-		)
+		md = CreateGoldmark(extenders...)
 		context := parser.NewContext()
 		doc = md.Parser().Parse(gtext.NewReader(btext), parser.WithContext(context))
 	}


### PR DESCRIPTION
This adds a table of contents generator.
It's based on #106 (and includes it in-line).

Since the toc generator is purely ast-based, we simply insert it into our own ast transformation pipeline.
This bypasses the cost of re-parsing, which is typically O(n^4), and makes it near-free when disabled.

This also adds some configurability on the user-end.
The toc frontmatter can have the values "true", "false", or an integer.
True is equivalent to 0, false to -1, and values >0 are translated to a maxheading of the value +1 (to account for titles being level 2).