### PR TITLE
chore: add pico+ to latest expiration date instead of now

### DIFF
--- a/db/postgres/storage.go
+++ b/db/postgres/storage.go
@@ -1613,12 +1613,11 @@ func (me *PsqlDB) FindTokensForUser(userID string) ([]*db.Token, error) {
 
 func (me *PsqlDB) createFeatureExpiresAt(userID, name string) time.Time {
 	ff, _ := me.FindFeatureForUser(userID, name)
-	t := time.Now()
-	extendDate := t.AddDate(1, 0, 0)
-	if ff != nil {
-		extendDate = ff.ExpiresAt.AddDate(1, 0, 0)
+	if ff == nil {
+		t := time.Now()
+		return t.AddDate(1, 0, 0)
 	}
-	return extendDate
+	return ff.ExpiresAt.AddDate(1, 0, 0)
 }
 
 func (me *PsqlDB) AddPicoPlusUser(username, paymentType, txId string) error {


### PR DESCRIPTION
When a user eventually purchases another year of pico+, we don't want to set the expiration date a year from purchase date.  Rather, we want to set the expiration date to the expiration date of the feature + 1 year.