### PR TITLE
Readme: Bump required version to 1.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Read our docs at [pico.sh](https://pico.sh).
 
 ## development
 
-- `golang` >= 1.21.0
+- `golang` >= 1.22.0
 - `direnv` to load environment vars
 
 ```bash


### PR DESCRIPTION
Since 15dc5a8706fc81e59f1f11320202400811137b8f the minimum required go version is 1.22.0.

This updates the readme to reflect that change