### PR TITLE
Fix silent failure on invalid redirect syntax

### DIFF
--- a/pgs/redirect.go
+++ b/pgs/redirect.go
@@ -98,7 +98,7 @@ func parseRedirectText(text string) ([]*RedirectRule, error) {
 		}
 
 		from := parts[0]
-		rest := parts[0:]
+		rest := parts[1:]
 		status, forced := hasStatusCode(rest[0])
 		if status != 0 {
 			rules = append(rules, &RedirectRule{
@@ -118,9 +118,9 @@ func parseRedirectText(text string) ([]*RedirectRule, error) {
 				return rules, fmt.Errorf("the destination path/URL must start with '/', 'http:' or 'https:'")
 			}
 
-			queryParts := parts[:toIndex]
-			to := parts[toIndex]
-			lastParts := parts[toIndex+1:]
+			queryParts := rest[:toIndex]
+			to := rest[toIndex]
+			lastParts := rest[toIndex+1:]
 			conditions := map[string]string{}
 			sts := http.StatusOK
 			frcd := false

--- a/pgs/redirect_test.go
+++ b/pgs/redirect_test.go
@@ -10,6 +10,7 @@ type RedirectFixture struct {
 	name   string
 	input  string
 	expect []*RedirectRule
+	shouldError bool
 }
 
 func TestParseRedirectText(t *testing.T) {
@@ -56,16 +57,39 @@ func TestParseRedirectText(t *testing.T) {
 		},
 	}
 
+	absoluteUriNoProto := RedirectFixture{
+		name:  "absolute-uri-no-proto",
+		input: "/*  www.example.com  301",
+		expect: []*RedirectRule{},
+		shouldError: true,
+	}
+
+	absoluteUriWithProto := RedirectFixture{
+		name:  "absolute-uri-no-proto",
+		input: "/*  https://www.example.com  301",
+		expect: []*RedirectRule{
+			{
+				From:       "/*",
+				To:         "https://www.example.com",
+				Status:     301,
+				Query:      empty,
+				Conditions: empty,
+			},
+		},
+	}
+
 	fixtures := []RedirectFixture{
 		spa,
 		withStatus,
 		noStatus,
+		absoluteUriNoProto,
+		absoluteUriWithProto,
 	}
 
 	for _, fixture := range fixtures {
 		t.Run(fixture.name, func(t *testing.T) {
 			results, err := parseRedirectText(fixture.input)
-			if err != nil {
+			if err != nil && !fixture.shouldError {
 				t.Error(err)
 			}
 			if cmp.Equal(results, fixture.expect) == false {


### PR DESCRIPTION
Hello! I'm a new (happy) Pico user who recently tried to set up a redirection for my pgs site like this: https://pico.sh/pgs#redirect-www-to-naked-domain

I found there was an off-by-one error in the parsing of `_redirects` files that caused the `the destination path/URL must start with '/', 'http:' or 'https:` validation to never trigger.

If there is no valid "To Part" in the string, but the "From Part" was valid, the previous code would use the "From Part" as the "To Part". For example, the version in the docs `/*  naked-domain.com  301` would be parsed as `From: "/*" , To: "/*", Status: 301`

The updated code throws an error, which I guess would become a 502 error. I've also updated the docs in another PR: https://github.com/picosh/docs/pull/5