### PR TITLE
Limit size of _redirects and _headers files

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -16,7 +16,7 @@ echo dotenv > .envrc && direnv allow
 Boot up database (or bring your own)
 
 ```bash
-docker compose up -f docker-compose.yml -f docker-compose.override.yml --profile db -d
+docker compose -f docker-compose.yml -f docker-compose.override.yml --profile db up -d
 ```
 
 Create db and migrate

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -8,6 +8,9 @@ import (
 var maxSize = uint64(25 * utils.MB)
 var maxAssetSize = int64(10 * utils.MB)
 
+// Needs to be small for caching files like _headers and _redirects.
+var maxSpecialFileSize = int64(5 * utils.KB)
+
 func NewConfigSite() *shared.ConfigSite {
 	domain := utils.GetEnv("PGS_DOMAIN", "pgs.sh")
 	port := utils.GetEnv("PGS_WEB_PORT", "3000")
@@ -23,19 +26,20 @@ func NewConfigSite() *shared.ConfigSite {
 	}
 
 	cfg := shared.ConfigSite{
-		Secret:       secret,
-		Domain:       domain,
-		Port:         port,
-		Protocol:     protocol,
-		DbURL:        dbURL,
-		StorageDir:   storageDir,
-		MinioURL:     minioURL,
-		MinioUser:    minioUser,
-		MinioPass:    minioPass,
-		Space:        "pgs",
-		MaxSize:      maxSize,
-		MaxAssetSize: maxAssetSize,
-		Logger:       shared.CreateLogger("pgs"),
+		Secret:             secret,
+		Domain:             domain,
+		Port:               port,
+		Protocol:           protocol,
+		DbURL:              dbURL,
+		StorageDir:         storageDir,
+		MinioURL:           minioURL,
+		MinioUser:          minioUser,
+		MinioPass:          minioPass,
+		Space:              "pgs",
+		MaxSize:            maxSize,
+		MaxAssetSize:       maxAssetSize,
+		MaxSpecialFileSize: maxSpecialFileSize,
+		Logger:             shared.CreateLogger("pgs"),
 	}
 
 	return &cfg

--- a/prose/config.go
+++ b/prose/config.go
@@ -17,6 +17,7 @@ func NewConfigSite() *shared.ConfigSite {
 	dbURL := utils.GetEnv("DATABASE_URL", "")
 	maxSize := uint64(500 * utils.MB)
 	maxImgSize := int64(10 * utils.MB)
+	maxSpecialFileSize := int64(5 * utils.KB)
 	secret := utils.GetEnv("PICO_SECRET", "")
 	if secret == "" {
 		panic("must provide PICO_SECRET environment variable")
@@ -44,9 +45,10 @@ func NewConfigSite() *shared.ConfigSite {
 			".svg",
 			".ico",
 		},
-		HiddenPosts:  []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
-		Logger:       shared.CreateLogger("prose"),
-		MaxSize:      maxSize,
-		MaxAssetSize: maxImgSize,
+		HiddenPosts:        []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
+		Logger:             shared.CreateLogger("prose"),
+		MaxSize:            maxSize,
+		MaxAssetSize:       maxImgSize,
+		MaxSpecialFileSize: maxSpecialFileSize,
 	}
 }

--- a/shared/config.go
+++ b/shared/config.go
@@ -28,24 +28,25 @@ type PageData struct {
 }
 
 type ConfigSite struct {
-	Debug        bool
-	SendgridKey  string
-	Secret       string
-	Domain       string
-	Port         string
-	PortOverride string
-	Protocol     string
-	DbURL        string
-	StorageDir   string
-	MinioURL     string
-	MinioUser    string
-	MinioPass    string
-	Space        string
-	AllowedExt   []string
-	HiddenPosts  []string
-	MaxSize      uint64
-	MaxAssetSize int64
-	Logger       *slog.Logger
+	Debug              bool
+	SendgridKey        string
+	Secret             string
+	Domain             string
+	Port               string
+	PortOverride       string
+	Protocol           string
+	DbURL              string
+	StorageDir         string
+	MinioURL           string
+	MinioUser          string
+	MinioPass          string
+	Space              string
+	AllowedExt         []string
+	HiddenPosts        []string
+	MaxSize            uint64
+	MaxAssetSize       int64
+	MaxSpecialFileSize int64
+	Logger             *slog.Logger
 }
 
 func NewConfigSite() *ConfigSite {


### PR DESCRIPTION
Related to discussion in #149

This PR limits _redirects and _headers files to 5KB. If they are larger than 5KB, the user's site will return 500 errors.

This is needed before we can consider caching these files since it sets an upper bound on our cache size. I also think it's just a good idea on its own since parsing 25MB of regexes could cause a denial of service.