### PR TITLE
Limit size of _redirects and _headers files

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -224,13 +224,14 @@ type FeatureFlag struct {
 	Data             FeatureFlagData `json:"data"`
 }
 
-func NewFeatureFlag(userID, name string, storageMax uint64, fileMax int64) *FeatureFlag {
+func NewFeatureFlag(userID, name string, storageMax uint64, fileMax int64, specialFileMax int64) *FeatureFlag {
 	return &FeatureFlag{
 		UserID: userID,
 		Name:   name,
 		Data: FeatureFlagData{
-			StorageMax: storageMax,
-			FileMax:    fileMax,
+			StorageMax:     storageMax,
+			FileMax:        fileMax,
+			SpecialFileMax: specialFileMax,
 		},
 	}
 }
@@ -249,6 +250,13 @@ func (ff *FeatureFlag) FindFileMax(defaultSize int64) int64 {
 	return ff.Data.FileMax
 }
 
+func (ff *FeatureFlag) FindSpecialFileMax(defaultSize int64) int64 {
+	if ff.Data.SpecialFileMax == 0 {
+		return defaultSize
+	}
+	return ff.Data.SpecialFileMax
+}
+
 func (ff *FeatureFlag) IsValid() bool {
 	if ff.ExpiresAt.IsZero() {
 		return false
@@ -257,8 +265,9 @@ func (ff *FeatureFlag) IsValid() bool {
 }
 
 type FeatureFlagData struct {
-	StorageMax uint64 `json:"storage_max"`
-	FileMax    int64  `json:"file_max"`
+	StorageMax     uint64 `json:"storage_max"`
+	FileMax        int64  `json:"file_max"`
+	SpecialFileMax int64  `json:"special_file_max"`
 }
 
 // Make the Attrs struct implement the driver.Valuer interface. This method

--- a/dev.md
+++ b/dev.md
@@ -16,7 +16,7 @@ echo dotenv > .envrc && direnv allow
 Boot up database (or bring your own)
 
 ```bash
-docker compose up -f docker-compose.yml -f docker-compose.override.yml --profile db -d
+docker compose -f docker-compose.yml -f docker-compose.override.yml --profile db up -d
 ```
 
 Create db and migrate

--- a/pgs/cli.go
+++ b/pgs/cli.go
@@ -302,7 +302,7 @@ func (c *Cmd) statsSites() error {
 func (c *Cmd) stats(cfgMaxSize uint64) error {
 	ff, err := c.Dbpool.FindFeatureForUser(c.User.ID, "plus")
 	if err != nil {
-		ff = db.NewFeatureFlag(c.User.ID, "plus", cfgMaxSize, 0)
+		ff = db.NewFeatureFlag(c.User.ID, "plus", cfgMaxSize, 0, 0)
 	}
 	// this is jank
 	ff.Data.StorageMax = ff.FindStorageMax(cfgMaxSize)

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -8,6 +8,9 @@ import (
 var maxSize = uint64(25 * utils.MB)
 var maxAssetSize = int64(10 * utils.MB)
 
+// Needs to be small for caching files like _headers and _redirects.
+var maxSpecialFileSize = int64(5 * utils.KB)
+
 func NewConfigSite() *shared.ConfigSite {
 	domain := utils.GetEnv("PGS_DOMAIN", "pgs.sh")
 	port := utils.GetEnv("PGS_WEB_PORT", "3000")
@@ -23,19 +26,20 @@ func NewConfigSite() *shared.ConfigSite {
 	}
 
 	cfg := shared.ConfigSite{
-		Secret:       secret,
-		Domain:       domain,
-		Port:         port,
-		Protocol:     protocol,
-		DbURL:        dbURL,
-		StorageDir:   storageDir,
-		MinioURL:     minioURL,
-		MinioUser:    minioUser,
-		MinioPass:    minioPass,
-		Space:        "pgs",
-		MaxSize:      maxSize,
-		MaxAssetSize: maxAssetSize,
-		Logger:       shared.CreateLogger("pgs"),
+		Secret:             secret,
+		Domain:             domain,
+		Port:               port,
+		Protocol:           protocol,
+		DbURL:              dbURL,
+		StorageDir:         storageDir,
+		MinioURL:           minioURL,
+		MinioUser:          minioUser,
+		MinioPass:          minioPass,
+		Space:              "pgs",
+		MaxSize:            maxSize,
+		MaxAssetSize:       maxAssetSize,
+		MaxSpecialFileSize: maxSpecialFileSize,
+		Logger:             shared.CreateLogger("pgs"),
 	}
 
 	return &cfg

--- a/prose/config.go
+++ b/prose/config.go
@@ -17,7 +17,6 @@ func NewConfigSite() *shared.ConfigSite {
 	dbURL := utils.GetEnv("DATABASE_URL", "")
 	maxSize := uint64(500 * utils.MB)
 	maxImgSize := int64(10 * utils.MB)
-	maxSpecialFileSize := int64(5 * utils.KB)
 	secret := utils.GetEnv("PICO_SECRET", "")
 	if secret == "" {
 		panic("must provide PICO_SECRET environment variable")
@@ -45,10 +44,9 @@ func NewConfigSite() *shared.ConfigSite {
 			".svg",
 			".ico",
 		},
-		HiddenPosts:        []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
-		Logger:             shared.CreateLogger("prose"),
-		MaxSize:            maxSize,
-		MaxAssetSize:       maxImgSize,
-		MaxSpecialFileSize: maxSpecialFileSize,
+		HiddenPosts:  []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
+		Logger:       shared.CreateLogger("prose"),
+		MaxSize:      maxSize,
+		MaxAssetSize: maxImgSize,
 	}
 }

--- a/prose/config.go
+++ b/prose/config.go
@@ -17,6 +17,7 @@ func NewConfigSite() *shared.ConfigSite {
 	dbURL := utils.GetEnv("DATABASE_URL", "")
 	maxSize := uint64(500 * utils.MB)
 	maxImgSize := int64(10 * utils.MB)
+	maxSpecialFileSize := int64(5 * utils.KB)
 	secret := utils.GetEnv("PICO_SECRET", "")
 	if secret == "" {
 		panic("must provide PICO_SECRET environment variable")
@@ -44,9 +45,10 @@ func NewConfigSite() *shared.ConfigSite {
 			".svg",
 			".ico",
 		},
-		HiddenPosts:  []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
-		Logger:       shared.CreateLogger("prose"),
-		MaxSize:      maxSize,
-		MaxAssetSize: maxImgSize,
+		HiddenPosts:        []string{"_readme.md", "_styles.css", "_footer.md", "_404.md"},
+		Logger:             shared.CreateLogger("prose"),
+		MaxSize:            maxSize,
+		MaxAssetSize:       maxImgSize,
+		MaxSpecialFileSize: maxSpecialFileSize,
 	}
 }

--- a/shared/config.go
+++ b/shared/config.go
@@ -28,24 +28,25 @@ type PageData struct {
 }
 
 type ConfigSite struct {
-	Debug        bool
-	SendgridKey  string
-	Secret       string
-	Domain       string
-	Port         string
-	PortOverride string
-	Protocol     string
-	DbURL        string
-	StorageDir   string
-	MinioURL     string
-	MinioUser    string
-	MinioPass    string
-	Space        string
-	AllowedExt   []string
-	HiddenPosts  []string
-	MaxSize      uint64
-	MaxAssetSize int64
-	Logger       *slog.Logger
+	Debug              bool
+	SendgridKey        string
+	Secret             string
+	Domain             string
+	Port               string
+	PortOverride       string
+	Protocol           string
+	DbURL              string
+	StorageDir         string
+	MinioURL           string
+	MinioUser          string
+	MinioPass          string
+	Space              string
+	AllowedExt         []string
+	HiddenPosts        []string
+	MaxSize            uint64
+	MaxAssetSize       int64
+	MaxSpecialFileSize int64
+	Logger             *slog.Logger
 }
 
 func NewConfigSite() *ConfigSite {

--- a/shared/ssh.go
+++ b/shared/ssh.go
@@ -93,11 +93,13 @@ func (r *SshAuthHandler) PubkeyAuthHandler(ctx ssh.Context, key ssh.PublicKey) b
 			"plus",
 			r.Cfg.MaxSize,
 			r.Cfg.MaxAssetSize,
+			r.Cfg.MaxSpecialFileSize,
 		)
 	}
 	// this is jank
 	ff.Data.StorageMax = ff.FindStorageMax(r.Cfg.MaxSize)
 	ff.Data.FileMax = ff.FindFileMax(r.Cfg.MaxAssetSize)
+	ff.Data.SpecialFileMax = ff.FindSpecialFileMax(r.Cfg.MaxSpecialFileSize)
 
 	SetUser(ctx, user)
 	SetFeatureFlag(ctx, ff)


### PR DESCRIPTION
Updated version of #150 to applies to both when the files are written to minio and when they are read from minio.

This PR limits _redirects and _headers files to 5KB. If they are larger than 5KB, the user's site will return 500 errors.

I think this is a good idea since parsing these files is done on every request and parsing 25MB of regexes could cause a denial of service.