### PR TITLE
Implement caching using Souin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ FEEDS_DOMAIN=feeds.dev.pico.sh:3004
 FEEDS_PROTOCOL=http
 FEEDS_DEBUG=1
 
-PGS_CADDYFILE=./caddy/Caddyfile
+PGS_CADDYFILE=./caddy/Caddyfile.pgs
 PGS_V4=
 PGS_V6=
 PGS_HTTP_V4=$PGS_V4:80
@@ -118,6 +118,8 @@ PGS_DOMAIN=pgs.dev.pico.sh:3005
 PGS_PROTOCOL=http
 PGS_STORAGE_DIR=.storage
 PGS_DEBUG=1
+PGS_CACHE_USER=testuser
+PGS_CACHE_PASSWORD=password
 
 PICO_CADDYFILE=./caddy/Caddyfile.pico
 PICO_V4=

--- a/caddy/Caddyfile.pgs
+++ b/caddy/Caddyfile.pgs
@@ -7,14 +7,34 @@
 	servers {
 		metrics
 	}
+	cache {
+		ttl 300s
+		max_cacheable_body_bytes 1000000
+		otter
+		api {
+			souin
+		}
+	}
 }
 
 *.{$APP_DOMAIN}, {$APP_DOMAIN} {
-	reverse_proxy web:3000
 	tls {$APP_EMAIL} {
 		dns cloudflare {$CF_API_TOKEN}
 		resolvers 1.1.1.1
 	}
+	route {
+		@souinApi path /souin-api/*
+		basic_auth @souinApi {
+			testuser $2a$14$i1G0lil5qti7qahb4.Kte.wP/3O8uaStduzhBBtuDUZhMJeSjxbqm
+		}
+		cache {
+			regex {
+				exclude /check
+			}
+		}
+		reverse_proxy web:3000
+	}
+
 	encode zstd gzip
 
 	header {

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -8,7 +8,9 @@ ARG TARGETARCH
 ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare
+    --with github.com/caddy-dns/cloudflare \
+    --with github.com/darkweak/souin/plugins/caddy@v1.7.2 \
+    --with github.com/darkweak/storages/otter/caddy
 
 FROM caddy:alpine
 

--- a/pgs/api.go
+++ b/pgs/api.go
@@ -354,6 +354,9 @@ func (h *AssetHandler) handle(logger *slog.Logger, w http.ResponseWriter, r *htt
 		w.Header().Set("content-type", contentType)
 	}
 
+	// Allows us to invalidate the cache when files are modified
+	w.Header().Set("surrogate-key", h.Subdomain)
+
 	finContentType := w.Header().Get("content-type")
 
 	// only track pages, not individual assets

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -16,6 +16,8 @@ func NewConfigSite() *shared.ConfigSite {
 	port := utils.GetEnv("PGS_WEB_PORT", "3000")
 	protocol := utils.GetEnv("PGS_PROTOCOL", "https")
 	storageDir := utils.GetEnv("PGS_STORAGE_DIR", ".storage")
+	pgsCacheUser := utils.GetEnv("PGS_CACHE_USER", "")
+	pgsCachePass := utils.GetEnv("PGS_CACHE_PASSWORD", "")
 	minioURL := utils.GetEnv("MINIO_URL", "")
 	minioUser := utils.GetEnv("MINIO_ROOT_USER", "")
 	minioPass := utils.GetEnv("MINIO_ROOT_PASSWORD", "")
@@ -32,6 +34,8 @@ func NewConfigSite() *shared.ConfigSite {
 		Protocol:           protocol,
 		DbURL:              dbURL,
 		StorageDir:         storageDir,
+		CacheUser:          pgsCacheUser,
+		CachePassword:      pgsCachePass,
 		MinioURL:           minioURL,
 		MinioUser:          minioUser,
 		MinioPass:          minioPass,

--- a/shared/config.go
+++ b/shared/config.go
@@ -37,6 +37,8 @@ type ConfigSite struct {
 	Protocol           string
 	DbURL              string
 	StorageDir         string
+	CacheUser          string
+	CachePassword      string
 	MinioURL           string
 	MinioUser          string
 	MinioPass          string


### PR DESCRIPTION
Fixes #149 

This PR implements in-memory caching of pgs response bodies inside Caddy using [a plugin](https://github.com/caddyserver/cache-handler) called [Souin](https://github.com/darkweak/souin).

### Background

Currently, serving a single asset from pgs can be a little slower than it could be due to DNS lookups, DB queries, and re-reading _headers and _redirects. Experiments in #151 showed that all these expensive operations are necessary and they cannot be simply cached in-process since pgs-web and pgs-ssh are separate processes that both need control over the cache. Thus, we have to use a cache like Souin which runs separate from pgs-web and pgs-ssh. But since it runs inside Caddy, no separate infrastructure is needed.

### How does the caching work?

When any user requests an asset like `https://example.com/styles.css` for the first time, the asset is fetched and returned to the user like normal, but now a copy of the response body and headers is stored by Souin (specifically using a high-performance in-memory store called [Otter](https://maypok86.github.io/otter/) which has impressive benchmarks and requires no special parameter tuning making it a good choice IMO). 

The cached response body is assigned a TTL of 5 minutes (which we could increase later if we get more confident with our cache flushing code). It's also associated with two keys:

* There's a main key which looks like `GET-https-example.com-/styles.css`. This key is used for quickly serving existing cached files when new requests arrive for the same assets.
* We also set a "[surrogate key](https://docs.fastly.com/en/guides/working-with-surrogate-keys)" which looks like `fakeuser-www-proj` (this matches the `*.pgs.sh` subdomain or the value in the TXT entry). This key is used for purging the cache for an entire project when any files are modified.

If any other users request the same file within 5 minutes, the responses will be served directly by Caddy from the in-memory cache. After 5 minutes, the cache for that asset expires.

Caveat: The cache is limited to 10,000 items. Otter uses [a special algorithm](https://s3fifo.com/) to evict rarely-accessed items from the cache to make room for new items.

### How does cache purging work?

Souin has an [API](https://github.com/darkweak/souin?tab=readme-ov-file#souin-api) for examining and purging entries from the cache. Unfortunately, there's [no way to expose this API on a different port](https://github.com/caddyserver/cache-handler/issues/106), so we have to protect it from abuse with Basic Auth.

When any files are written or deleted (like with [rsync](https://pico.sh/pgs#publish-your-site-with-one-command)), we use a golang channel to asynchronously purge the cache for the entire project by using [surrogate keys](https://docs.fastly.com/en/guides/working-with-surrogate-keys). This involves sending an HTTP request to `PURGE https://pgs.sh/souin-api/souin/`. These purge requests are debounced so that we only purge the cache once per site per 5 seconds.

This API is reachable from the public internet, just protected with basic auth. So in case of emergencies, admins can do things like `curl -i -X PURGE -u testuser:password https://pgs.sh/souin-api/souin/flush` to purge the entire cache.


### FAQ

* How much RAM will this use?
    - 50th percentile asset size seems to be around [500KB](https://almanac.httparchive.org/en/2021/page-weight) so a full cache (10,000 items) could be 5GB. Max theoretical is 10GB due to the 1MB `max_cacheable_body_bytes`.
* Are there any infrastructure changes required?
   - Mostly no. You'll need to rebuild/repush the Caddy image and you should generate a new basic_auth username/password.
* What isn't cached?
   - Errors, and the `/check` endpoint. Everything else (including the assets for https://pgs.sh) is cached.
* Are private pages still kept private?
    - I think so, since those requests bypass Caddy and go straight to `pgs-ssh`.

### Still TODO

* Actually execute this code. I tested individual parts but not the whole thing yet.
* Make sure this doesn't break other services like `imgs` or `prose`.
* **Figure out what to do about analytics.** Cached responses never hit pgs-web, so it can't increment counters in the DB. An easy/temp option could be not caching HTML files, but then we lose a lot of the benefits of caching. Possibly later we could pull page view counts from Caddy prometheus metrics.

Open to feedback and questions!

