### PR TITLE
Implement caching using Souin (take 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ FEEDS_DOMAIN=feeds.dev.pico.sh:3004
 FEEDS_PROTOCOL=http
 FEEDS_DEBUG=1
 
-PGS_CADDYFILE=./caddy/Caddyfile
+PGS_CADDYFILE=./caddy/Caddyfile.pgs
 PGS_V4=
 PGS_V6=
 PGS_HTTP_V4=$PGS_V4:80
@@ -118,6 +118,8 @@ PGS_DOMAIN=pgs.dev.pico.sh:3005
 PGS_PROTOCOL=http
 PGS_STORAGE_DIR=.storage
 PGS_DEBUG=1
+PGS_CACHE_USER=testuser
+PGS_CACHE_PASSWORD=password
 
 PICO_CADDYFILE=./caddy/Caddyfile.pico
 PICO_V4=

--- a/caddy/Caddyfile.pgs
+++ b/caddy/Caddyfile.pgs
@@ -8,6 +8,14 @@
 		metrics
 		trusted_proxies static 0.0.0.0/0
 	}
+	cache {
+		ttl 300s
+		max_cacheable_body_bytes 1000000
+		otter
+		api {
+			souin
+		}
+	}
 }
 
 *.{$APP_DOMAIN}, {$APP_DOMAIN} {
@@ -21,6 +29,19 @@
 		dns cloudflare {$CF_API_TOKEN}
 		resolvers 1.1.1.1
 	}
+	route {
+		@souinApi path /souin-api/*
+		basic_auth @souinApi {
+			testuser $2a$14$i1G0lil5qti7qahb4.Kte.wP/3O8uaStduzhBBtuDUZhMJeSjxbqm
+		}
+		cache {
+			regex {
+				exclude /check
+			}
+		}
+		reverse_proxy web:3000
+	}
+
 	encode zstd gzip
 
 	header {

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -9,7 +9,7 @@ ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
 RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
-    --with github.com/darkweak/souin/plugins/caddy@v1.7.4 \
+    --with github.com/darkweak/souin/plugins/caddy@v1.7.5 \
     --with github.com/darkweak/storages/otter/caddy
 
 FROM caddy:alpine

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -9,7 +9,7 @@ ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
 RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
-    --with github.com/darkweak/souin/plugins/caddy@v1.7.2 \
+    --with github.com/darkweak/souin/plugins/caddy@v1.7.4 \
     --with github.com/darkweak/storages/otter/caddy
 
 FROM caddy:alpine

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -8,7 +8,9 @@ ARG TARGETARCH
 ENV GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare
+    --with github.com/caddy-dns/cloudflare \
+    --with github.com/darkweak/souin/plugins/caddy@v1.7.2 \
+    --with github.com/darkweak/storages/otter/caddy
 
 FROM caddy:alpine
 

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -16,6 +16,8 @@ func NewConfigSite() *shared.ConfigSite {
 	port := utils.GetEnv("PGS_WEB_PORT", "3000")
 	protocol := utils.GetEnv("PGS_PROTOCOL", "https")
 	storageDir := utils.GetEnv("PGS_STORAGE_DIR", ".storage")
+	pgsCacheUser := utils.GetEnv("PGS_CACHE_USER", "")
+	pgsCachePass := utils.GetEnv("PGS_CACHE_PASSWORD", "")
 	minioURL := utils.GetEnv("MINIO_URL", "")
 	minioUser := utils.GetEnv("MINIO_ROOT_USER", "")
 	minioPass := utils.GetEnv("MINIO_ROOT_PASSWORD", "")
@@ -27,6 +29,8 @@ func NewConfigSite() *shared.ConfigSite {
 		Protocol:           protocol,
 		DbURL:              dbURL,
 		StorageDir:         storageDir,
+		CacheUser:          pgsCacheUser,
+		CachePassword:      pgsCachePass,
 		MinioURL:           minioURL,
 		MinioUser:          minioUser,
 		MinioPass:          minioPass,

--- a/pgs/uploader.go
+++ b/pgs/uploader.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/ssh"
@@ -97,16 +99,21 @@ type FileData struct {
 }
 
 type UploadAssetHandler struct {
-	DBPool  db.DB
-	Cfg     *shared.ConfigSite
-	Storage sst.ObjectStorage
+	DBPool             db.DB
+	Cfg                *shared.ConfigSite
+	Storage            sst.ObjectStorage
+	CacheClearingQueue chan string
 }
 
 func NewUploadAssetHandler(dbpool db.DB, cfg *shared.ConfigSite, storage sst.ObjectStorage) *UploadAssetHandler {
+	// Enable buffering so we don't slow down uploads.
+	ch := make(chan string, 100)
+	go runCacheQueue(ch, cfg)
 	return &UploadAssetHandler{
-		DBPool:  dbpool,
-		Cfg:     cfg,
-		Storage: storage,
+		DBPool:             dbpool,
+		Cfg:                cfg,
+		Storage:            storage,
+		CacheClearingQueue: ch,
 	}
 }
 
@@ -405,6 +412,7 @@ func (h *UploadAssetHandler) Write(s ssh.Session, entry *sendutils.FileEntry) (s
 		utils.BytesToGB(maxSize),
 		(float32(nextStorageSize)/float32(maxSize))*100,
 	)
+	h.CacheClearingQueue <- fmt.Sprintf("%s-%s", user.Name, projectName)
 
 	return str, nil
 }
@@ -471,8 +479,9 @@ func (h *UploadAssetHandler) Delete(s ssh.Session, entry *sendutils.FileEntry) e
 			return err
 		}
 	}
-
-	return h.Storage.DeleteObject(bucket, assetFilepath)
+	err = h.Storage.DeleteObject(bucket, assetFilepath)
+	h.CacheClearingQueue <- fmt.Sprintf("%s-%s", user.Name, projectName)
+	return err
 }
 
 func (h *UploadAssetHandler) validateAsset(data *FileData) (bool, error) {
@@ -517,4 +526,57 @@ func (h *UploadAssetHandler) writeAsset(reader io.Reader, data *FileData) (int64
 		data.FileEntry,
 	)
 	return fsize, err
+}
+
+// runCacheQueue processes requests to purge the cache for a single site.
+// One message arrives per file that is written/deleted during uploads.
+// Repeated messages for the same site are grouped so that we only flush once
+// per site per 5 seconds.
+func runCacheQueue(ch chan string, cfg *shared.ConfigSite) {
+	cacheApiUrl := fmt.Sprintf("https://%s/souin-api/souin/", cfg.Domain)
+	var pendingFlushes sync.Map
+	tick := time.Tick(5 * time.Second)
+	for {
+		select {
+		case host := <-ch:
+			pendingFlushes.Store(host, host)
+		case <-tick:
+			go func() {
+				pendingFlushes.Range(func(key, value any) bool {
+					pendingFlushes.Delete(key)
+					err := purgeCache(key.(string), cacheApiUrl, cfg.CacheUser, cfg.CachePassword)
+					if err != nil {
+						cfg.Logger.Error("failed to clear cache", "err", err.Error())
+					}
+					return true
+				})
+			}()
+		}
+	}
+}
+
+// purgeCache send an HTTP request to the pgs Caddy instance which purges
+// cached entries for a given subdomain (like "fakeuser-www-proj"). We set a
+// "surrogate-key: <subdomain>" header on every pgs response which ensures all
+// cached assets for a given subdomain are grouped under a single key (which is
+// separate from the "GET-https-example.com-/path" key used for serving files
+// from the cache).
+func purgeCache(subdomain string, cacheApiUrl string, username string, password string) error {
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	req, err := http.NewRequest("PURGE", cacheApiUrl, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Surrogate-Key", subdomain)
+	req.SetBasicAuth(username, password)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("received unexpected response code %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/pgs/web_asset_handler.go
+++ b/pgs/web_asset_handler.go
@@ -121,6 +121,11 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				r.Host = destUrl.Host
 				r.URL = destUrl
 			}
+			// Disable caching
+			proxy.ModifyResponse = func(r *http.Response) error {
+				r.Header.Set("cache-control", "no-cache")
+				return nil
+			}
 			proxy.ServeHTTP(w, r)
 			return
 		}

--- a/pgs/web_asset_handler.go
+++ b/pgs/web_asset_handler.go
@@ -216,6 +216,9 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", contentType)
 	}
 
+	// Allows us to invalidate the cache when files are modified
+	w.Header().Set("surrogate-key", h.Subdomain)
+
 	finContentType := w.Header().Get("content-type")
 
 	logger.Info(

--- a/shared/config.go
+++ b/shared/config.go
@@ -38,6 +38,8 @@ type ConfigSite struct {
 	Protocol           string
 	DbURL              string
 	StorageDir         string
+	CacheUser          string
+	CachePassword      string
 	MinioURL           string
 	MinioUser          string
 	MinioPass          string


### PR DESCRIPTION
# Summary

This PR implements in-memory caching of pgs response bodies inside Caddy using [a plugin](https://github.com/caddyserver/cache-handler) called [Souin](https://github.com/darkweak/souin).

Fixes #149. Supersedes #154. The rest of this description is copied from #154, with changes bolded.

### Background

Currently, serving a single asset from pgs can be a little slower than it could be due to DNS lookups, DB queries, and re-reading _headers and _redirects. Experiments in #151 showed that all these expensive operations are necessary and they cannot be simply cached in-process since pgs-web and pgs-ssh are separate processes that both need control over the cache. Thus, we have to use a cache like Souin which runs separate from pgs-web and pgs-ssh. But since it runs inside Caddy, no separate infrastructure is needed.

### How does the caching work?

When any user requests an asset like `https://example.com/styles.css` for the first time, the asset is fetched and returned to the user like normal, but now a copy of the response body and headers is stored by Souin (specifically using a high-performance in-memory store called [Otter](https://maypok86.github.io/otter/) which has impressive benchmarks and requires no special parameter tuning making it a good choice IMO). 

The cached response body is assigned a TTL of 5 minutes (which we could increase later if we get more confident with our cache flushing code). Each cached body is also associated with two keys:

* There's a main key which looks like `GET-https-example.com-/styles.css`. This key is used for quickly serving existing cached files when new requests arrive for the same assets.
* We also set a "[surrogate key](https://docs.fastly.com/en/guides/working-with-surrogate-keys)" which looks like `fakeuser-www-proj` (this matches the `*.pgs.sh` subdomain or the value in the TXT entry). This key is used for purging the cache for an entire project when any files are modified.

If any other users request the same file within 5 minutes, the responses will be served directly by Caddy from the in-memory cache. After 5 minutes, the cache for that asset expires.

Caveat: The cache is limited to 10,000 items. Otter uses [a special algorithm](https://s3fifo.com/) to evict rarely-accessed items from the cache to make room for new items.

### How does cache purging work?

Souin has an [API](https://github.com/darkweak/souin?tab=readme-ov-file#souin-api) for examining and purging entries from the cache. Unfortunately, there's [no way to expose this API on a different port](https://github.com/caddyserver/cache-handler/issues/106), so we have to protect it from abuse with Basic Auth.

When any files are written or deleted (like with [rsync](https://pico.sh/pgs#publish-your-site-with-one-command)), we use a golang channel to asynchronously purge the cache for the entire project by using [surrogate keys](https://docs.fastly.com/en/guides/working-with-surrogate-keys). This involves sending an HTTP request to `PURGE https://pgs.sh/souin-api/souin/`. These purge requests are debounced so that we only purge the cache once per site per 5 seconds.

This API is reachable from the public internet, just protected with basic auth. So in case of emergencies, admins can do things like `curl -i -X PURGE -u testuser:password https://pgs.sh/souin-api/souin/flush` to purge the entire cache.

### FAQ

* How much RAM will this use?
    - 50th percentile asset size seems to be around [500KB](https://almanac.httparchive.org/en/2021/page-weight) so a full cache (10,000 items) could be 5GB. Max theoretical is 10GB due to the 1MB `max_cacheable_body_bytes`.
* Are there any infrastructure changes required?
   - Mostly no. You'll need to rebuild/repush the Caddy image and you should generate a new basic_auth username/password.
* What isn't cached?
   - Errors, and the `/check` endpoint. Everything else (including the assets for https://pgs.sh) is cached. **HTML files ARE now cached since the [pipe-based analytics](https://github.com/picosh/pico/issues/149#issuecomment-2479741044) is ready.**
* Are private pages still kept private?
    - Yes, since those requests bypass Caddy and go straight to `pgs-ssh`.
* **Will this work with multi-region pico?**
    - Technically yes, now that the [pipe-based analytics](https://github.com/picosh/pico/issues/149#issuecomment-2479741044) is ready. We'd have to modify `purgeCache` to loop over all the hostnames of all regional Caddy instances. Also note that Otter does not support clustering, so each regional instance of Caddy will have it's own independent cache.

### Still TODO

- [ ] Local end-to-end testing (haven't re-tested this since recreating the PR)
- [ ] Make sure this doesn't break other services like `imgs` or `prose`.

### TODO items for admins:
- [ ] Generate new basic auth password that isn't `password`
- [ ] After merging, rebuild the Caddy image (to include the Souin plugin)