### PR TITLE
feat(pgs): Configure cache-control, TTL, max body, exclude /check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,8 +118,7 @@ PGS_DOMAIN=pgs.dev.pico.sh:3005
 PGS_PROTOCOL=http
 PGS_STORAGE_DIR=.storage
 PGS_DEBUG=1
-PGS_CACHE_USER=testuser
-PGS_CACHE_PASSWORD=password
+PGS_CACHE_TTL=600s
 
 PICO_CADDYFILE=./caddy/Caddyfile.pico
 PICO_V4=

--- a/pgs/config.go
+++ b/pgs/config.go
@@ -1,6 +1,9 @@
 package pgs
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/picosh/pico/shared"
 	"github.com/picosh/utils"
 )
@@ -16,8 +19,13 @@ func NewConfigSite() *shared.ConfigSite {
 	port := utils.GetEnv("PGS_WEB_PORT", "3000")
 	protocol := utils.GetEnv("PGS_PROTOCOL", "https")
 	storageDir := utils.GetEnv("PGS_STORAGE_DIR", ".storage")
-	pgsCacheUser := utils.GetEnv("PGS_CACHE_USER", "")
-	pgsCachePass := utils.GetEnv("PGS_CACHE_PASSWORD", "")
+	cacheTTL, err := time.ParseDuration(utils.GetEnv("PGS_CACHE_TTL", ""))
+	if err != nil {
+		cacheTTL = 600 * time.Second
+	}
+	cacheControl := utils.GetEnv(
+		"PGS_CACHE_CONTROL",
+		fmt.Sprintf("max-age=%d", int(cacheTTL.Seconds())))
 	minioURL := utils.GetEnv("MINIO_URL", "")
 	minioUser := utils.GetEnv("MINIO_ROOT_USER", "")
 	minioPass := utils.GetEnv("MINIO_ROOT_PASSWORD", "")
@@ -29,8 +37,8 @@ func NewConfigSite() *shared.ConfigSite {
 		Protocol:           protocol,
 		DbURL:              dbURL,
 		StorageDir:         storageDir,
-		CacheUser:          pgsCacheUser,
-		CachePassword:      pgsCachePass,
+		CacheTTL:           cacheTTL,
+		CacheControl:       cacheControl,
 		MinioURL:           minioURL,
 		MinioUser:          minioUser,
 		MinioPass:          minioPass,

--- a/shared/config.go
+++ b/shared/config.go
@@ -38,8 +38,8 @@ type ConfigSite struct {
 	Protocol           string
 	DbURL              string
 	StorageDir         string
-	CacheUser          string
-	CachePassword      string
+	CacheTTL           time.Duration
+	CacheControl       string
 	MinioURL           string
 	MinioUser          string
 	MinioPass          string


### PR DESCRIPTION
* Increased the default TTL from 5 minutes to 10 minutes. 
    - Reason: Sounds like the cache clearing has been working so we should be safe to raise it. 10 minutes is the default `max-age` for all Github Pages sites so it's probably a good standard to match.
* Made the default TTL configurable
* Set the default `Cache-Control` header to `max-age: 600`
    - Reason: Right now, the default value is set to the empty string, which is under-specified, but generally interpreted as if the header were missing. If the header is missing, browsers will still cache content on the client-side, but without an explicit TTL they will use a heuristic for calculating their own TTL (typically [10% of the time since the Last-Modified date](https://paulcalvano.com/2018-03-14-http-heuristic-caching-missing-cache-control-and-expires-headers-explained/)). Explicitly setting the TTL is recommended instead of relying on that.
* Set the maximum cacheable body size. 
    - In #159 I originally set this to 1MB but I was lazy and didn't want to add another config value so I just set it to the current max file size of 10MB :) Beware of RAM-based DDoS! May want to set a RAM limit on your pgs container in docker-compose.
* Excluded `/check` from caching.
    - Reason: Currently Souin is not caching /check anyway, but only because of `UPSTREAM-ERROR-OR-EMPTY-RESPONSE`, so I just made this more explicit.

PS: Thanks for the shout-out in the [caching blog post](https://blog.pico.sh/ann-026-pages-http-caching)!