### PR TITLE
feat(pgs): initial support for conditional requests

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -7,6 +7,8 @@
 cp ./.env.example .env
 ```
 
+If you are running apps outside of docker, remember to change the postgres, minio, and imgproxy hostnames to "localhost" in `.env`.
+
 Initialize local env variables using direnv
 
 ```bash
@@ -30,6 +32,28 @@ make migrate
 go run ./cmd/pgs/ssh
 # in a separate terminal
 go run ./cmd/pgs/web
+```
+
+## sign up and upload files
+
+The initial database has no users, you need to sign up via pico/ssh:
+
+```bash
+go run ./cmd/pico/ssh
+# in a separate terminal, complete the signup flow, set your username to "picouser"
+ssh localhost -p 2222
+```
+
+Stop the pico SSH server, then you can upload files:
+
+```bash
+go run ./cmd/pgs/ssh
+# in a separate terminal
+go run ./cmd/pgs/web
+# in a third terminal
+echo 'Hello, World!' > file.txt
+scp -P 2222 file.txt localhost:/test/file.txt
+curl -iH "Host: picouser-test.pgs.dev.pico.sh" localhost:3000/file.txt
 ```
 
 ## deployment

--- a/pgs/fs.go
+++ b/pgs/fs.go
@@ -230,12 +230,6 @@ func isZeroTime(t time.Time) bool {
 	return t.IsZero() || t.Equal(unixEpochTime)
 }
 
-func setLastModified(w http.ResponseWriter, modtime time.Time) {
-	if !isZeroTime(modtime) {
-		w.Header().Set("Last-Modified", modtime.UTC().Format(http.TimeFormat))
-	}
-}
-
 func writeNotModified(w http.ResponseWriter) {
 	// RFC 7232 section 4.1:
 	// a sender SHOULD NOT generate representation metadata other than the

--- a/pgs/fs.go
+++ b/pgs/fs.go
@@ -1,0 +1,288 @@
+// Copyright 2009 The Go Authors.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// HTTP file system request handler
+//
+// Upstream: https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/fs.go
+// Modifications from upstream:
+// * Deleted everything except checkPreconditions and dependent functions
+// * Added "http" package prefixes
+
+package pgs
+
+import (
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+)
+
+// scanETag determines if a syntactically valid ETag is present at s. If so,
+// the ETag and remaining text after consuming ETag is returned. Otherwise,
+// it returns "", "".
+func scanETag(s string) (etag string, remain string) {
+	s = textproto.TrimString(s)
+	start := 0
+	if strings.HasPrefix(s, "W/") {
+		start = 2
+	}
+	if len(s[start:]) < 2 || s[start] != '"' {
+		return "", ""
+	}
+	// ETag is either W/"text" or "text".
+	// See RFC 7232 2.3.
+	for i := start + 1; i < len(s); i++ {
+		c := s[i]
+		switch {
+		// Character values allowed in ETags.
+		case c == 0x21 || c >= 0x23 && c <= 0x7E || c >= 0x80:
+		case c == '"':
+			return s[:i+1], s[i+1:]
+		default:
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+// etagStrongMatch reports whether a and b match using strong ETag comparison.
+// Assumes a and b are valid ETags.
+func etagStrongMatch(a, b string) bool {
+	return a == b && a != "" && a[0] == '"'
+}
+
+// etagWeakMatch reports whether a and b match using weak ETag comparison.
+// Assumes a and b are valid ETags.
+func etagWeakMatch(a, b string) bool {
+	return strings.TrimPrefix(a, "W/") == strings.TrimPrefix(b, "W/")
+}
+
+// condResult is the result of an HTTP request precondition check.
+// See https://tools.ietf.org/html/rfc7232 section 3.
+type condResult int
+
+const (
+	condNone condResult = iota
+	condTrue
+	condFalse
+)
+
+func checkIfMatch(w http.ResponseWriter, r *http.Request) condResult {
+	im := r.Header.Get("If-Match")
+	if im == "" {
+		return condNone
+	}
+	for {
+		im = textproto.TrimString(im)
+		if len(im) == 0 {
+			break
+		}
+		if im[0] == ',' {
+			im = im[1:]
+			continue
+		}
+		if im[0] == '*' {
+			return condTrue
+		}
+		etag, remain := scanETag(im)
+		if etag == "" {
+			break
+		}
+		if etagStrongMatch(etag, w.Header().Get("Etag")) {
+			return condTrue
+		}
+		im = remain
+	}
+
+	return condFalse
+}
+
+func checkIfUnmodifiedSince(r *http.Request, modtime time.Time) condResult {
+	ius := r.Header.Get("If-Unmodified-Since")
+	if ius == "" || isZeroTime(modtime) {
+		return condNone
+	}
+	t, err := http.ParseTime(ius)
+	if err != nil {
+		return condNone
+	}
+
+	// The Last-Modified header truncates sub-second precision so
+	// the modtime needs to be truncated too.
+	modtime = modtime.Truncate(time.Second)
+	if ret := modtime.Compare(t); ret <= 0 {
+		return condTrue
+	}
+	return condFalse
+}
+
+func checkIfNoneMatch(w http.ResponseWriter, r *http.Request) condResult {
+	inm := r.Header.Get("If-None-Match")
+	if inm == "" {
+		return condNone
+	}
+	buf := inm
+	for {
+		buf = textproto.TrimString(buf)
+		if len(buf) == 0 {
+			break
+		}
+		if buf[0] == ',' {
+			buf = buf[1:]
+			continue
+		}
+		if buf[0] == '*' {
+			return condFalse
+		}
+		etag, remain := scanETag(buf)
+		if etag == "" {
+			break
+		}
+		if etagWeakMatch(etag, w.Header().Get("Etag")) {
+			return condFalse
+		}
+		buf = remain
+	}
+	return condTrue
+}
+
+func checkIfModifiedSince(r *http.Request, modtime time.Time) condResult {
+	if r.Method != "GET" && r.Method != "HEAD" {
+		return condNone
+	}
+	ims := r.Header.Get("If-Modified-Since")
+	if ims == "" || isZeroTime(modtime) {
+		return condNone
+	}
+	t, err := http.ParseTime(ims)
+	if err != nil {
+		return condNone
+	}
+	// The Last-Modified header truncates sub-second precision so
+	// the modtime needs to be truncated too.
+	modtime = modtime.Truncate(time.Second)
+	if ret := modtime.Compare(t); ret <= 0 {
+		return condFalse
+	}
+	return condTrue
+}
+
+func checkIfRange(w http.ResponseWriter, r *http.Request, modtime time.Time) condResult {
+	if r.Method != "GET" && r.Method != "HEAD" {
+		return condNone
+	}
+	ir := r.Header.Get("If-Range")
+	if ir == "" {
+		return condNone
+	}
+	etag, _ := scanETag(ir)
+	if etag != "" {
+		if etagStrongMatch(etag, w.Header().Get("Etag")) {
+			return condTrue
+		} else {
+			return condFalse
+		}
+	}
+	// The If-Range value is typically the ETag value, but it may also be
+	// the modtime date. See golang.org/issue/8367.
+	if modtime.IsZero() {
+		return condFalse
+	}
+	t, err := http.ParseTime(ir)
+	if err != nil {
+		return condFalse
+	}
+	if t.Unix() == modtime.Unix() {
+		return condTrue
+	}
+	return condFalse
+}
+
+var unixEpochTime = time.Unix(0, 0)
+
+// isZeroTime reports whether t is obviously unspecified (either zero or Unix()=0).
+func isZeroTime(t time.Time) bool {
+	return t.IsZero() || t.Equal(unixEpochTime)
+}
+
+func setLastModified(w http.ResponseWriter, modtime time.Time) {
+	if !isZeroTime(modtime) {
+		w.Header().Set("Last-Modified", modtime.UTC().Format(http.TimeFormat))
+	}
+}
+
+func writeNotModified(w http.ResponseWriter) {
+	// RFC 7232 section 4.1:
+	// a sender SHOULD NOT generate representation metadata other than the
+	// above listed fields unless said metadata exists for the purpose of
+	// guiding cache updates (e.g., Last-Modified might be useful if the
+	// response does not have an ETag field).
+	h := w.Header()
+	delete(h, "Content-Type")
+	delete(h, "Content-Length")
+	delete(h, "Content-Encoding")
+	if h.Get("Etag") != "" {
+		delete(h, "Last-Modified")
+	}
+	w.WriteHeader(http.StatusNotModified)
+}
+
+// checkPreconditions evaluates request preconditions and reports whether a precondition
+// resulted in sending http.StatusNotModified or http.StatusPreconditionFailed.
+func checkPreconditions(w http.ResponseWriter, r *http.Request, modtime time.Time) (done bool, rangeHeader string) {
+	// This function carefully follows RFC 7232 section 6.
+	ch := checkIfMatch(w, r)
+	if ch == condNone {
+		ch = checkIfUnmodifiedSince(r, modtime)
+	}
+	if ch == condFalse {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		return true, ""
+	}
+	switch checkIfNoneMatch(w, r) {
+	case condFalse:
+		if r.Method == "GET" || r.Method == "HEAD" {
+			writeNotModified(w)
+			return true, ""
+		} else {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return true, ""
+		}
+	case condNone:
+		if checkIfModifiedSince(r, modtime) == condFalse {
+			writeNotModified(w)
+			return true, ""
+		}
+	}
+
+	rangeHeader = r.Header.Get("Range")
+	if rangeHeader != "" && checkIfRange(w, r, modtime) == condFalse {
+		rangeHeader = ""
+	}
+	return false, rangeHeader
+}

--- a/pgs/web_asset_handler.go
+++ b/pgs/web_asset_handler.go
@@ -203,7 +203,7 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !info.LastModified.IsZero() {
-			w.Header().Add("last-modified", info.LastModified.Format(http.TimeFormat))
+			w.Header().Add("last-modified", info.LastModified.UTC().Format(http.TimeFormat))
 		}
 	}
 
@@ -225,7 +225,11 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"status", status,
 		"contentType", finContentType,
 	)
-
+	done, _ := checkPreconditions(w, r, info.LastModified.UTC())
+	if done {
+		// A conditional request was detected, status and headers are set, no body required (either 412 or 304)
+		return
+	}
 	w.WriteHeader(status)
 	_, err = io.Copy(w, contents)
 

--- a/pgs/web_asset_handler.go
+++ b/pgs/web_asset_handler.go
@@ -199,7 +199,8 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add("content-length", strconv.Itoa(int(info.Size)))
 		}
 		if info.ETag != "" {
-			w.Header().Add("etag", info.ETag)
+			// Minio SDK trims off the mandatory quotes (RFC 7232 § 2.3)
+			w.Header().Add("etag", fmt.Sprintf("\"%s\"", info.ETag))
 		}
 
 		if !info.LastModified.IsZero() {

--- a/shared/storage/memory.go
+++ b/shared/storage/memory.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"io"
 	"net/http"
+	"time"
 
 	sst "github.com/picosh/pobj/storage"
 )
@@ -23,6 +24,13 @@ func (s *StorageMemory) ServeObject(bucket sst.Bucket, fpath string, opts *ImgPr
 	obj, info, err := s.GetObject(bucket, fpath)
 	if info.Metadata == nil {
 		info.Metadata = make(http.Header)
+	}
+	// Make tests work by supplying non-null Last-Modified and Etag values
+	if info.LastModified.IsZero() {
+		info.LastModified = time.Now().UTC()
+	}
+	if info.ETag == "" {
+		info.ETag = "static-etag-for-testing-purposes"
 	}
 	mimeType := GetMimeType(fpath)
 	info.Metadata.Set("content-type", mimeType)


### PR DESCRIPTION
This PR provides initial support for conditional requests.

I copied the important RFC-compliant bits from https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/fs.go and used that to parse and set the right headers and status codes for conditional requests.

The alternative would be using `http.ServeContent`, but that requires an `io.ReadSeeker` which wouldn't work with files obtained from imgproxy since that returns an `io.ReadCloser`.

Ref: #177

* Looks like Souin ignores `If-Not-Modified` headers (https://github.com/darkweak/souin/issues/588), but this issue is technically not a blocker because browsers generally send both `If-Modified-Since` and `If-None-Match`, where the `If-None-Match` takes precedence (which souin does handle), making the conditional request flow work as expected. This is all allowed by the RFCs as far as I can tell.