### PR TITLE
fix(gha): only push images on merge/release

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,21 @@
+name: Lint and run tests
+
+description: Lints and runs tests on the codebase, used before builds and on every PR
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.23
+    - name: Lint the codebase
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        args: -E goimports -E godot --timeout 10m
+    - name: Run tests
+      shell: bash
+      run: |
+        PICO_SECRET="danger" go test -v ./... -cover -race -coverprofile=coverage.out
+        go tool cover -func=coverage.out -o=coverage.out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ on:
       - main
     tags:
       - v*
-  pull_request:
-    branches:
-      - main
 
 env:
   REGISTRY: ghcr.io
@@ -21,21 +18,10 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.23
     - name: Checkout repo
       uses: actions/checkout@v3
-    - name: Lint the codebase
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: latest
-        args: -E goimports -E godot --timeout 10m
-    - name: Run tests
-      run: |
-        PICO_SECRET="danger" go test -v ./... -cover -race -coverprofile=coverage.out
-        go tool cover -func=coverage.out -o=coverage.out
+    - name: Run tests and lint
+      uses: ./.github/actions/test
   build-main:
     runs-on: ubuntu-22.04
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Run tests and lint
+      uses: ./.github/actions/test


### PR DESCRIPTION
I've noticed all PRs have failing builds because the github action tries to push images to ghcr, which throws a 403 error.

After reading through https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ , I'm pretty sure the original goal of pushing images tagged with the PR number is not possible to do securely.

The GITHUB_TOKEN used for authenticating to ghcr by default does not have write permissions, hence the 403 error. We could "fix" this by using `pull_request_target`, but that is very insecure since anyone could fork the repo and use the GITHUB_TOKEN inside the pipeline to overwrite any image in ghcr ([or worse](https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection)).

So since there's no secure way (as far as I know) to allow pushing to ghcr in the context of PRs, I disabled it.

Now, PRs will just trigger the linting and testing steps. Merges to `main` and tag pushes will still trigger builds.