### PR TITLE
fix(pgs): never cache http-pass responses

### DIFF
--- a/pkg/apps/pgs/web.go
+++ b/pkg/apps/pgs/web.go
@@ -616,6 +616,7 @@ func (web *WebRouter) ServeAsset(fname string, opts *storage.ImgProcessOpts, has
 		Bucket:         bucket,
 		ImgProcessOpts: opts,
 		HasPicoPlus:    hasPicoPlus,
+		HttpPass:       project.Acl.Type == "http-pass",
 	}
 
 	asset.ServeHTTP(w, r)

--- a/pkg/apps/pgs/web_asset_handler.go
+++ b/pkg/apps/pgs/web_asset_handler.go
@@ -30,6 +30,7 @@ type ApiAssetHandler struct {
 	ImgProcessOpts *storage.ImgProcessOpts
 	ProjectID      string
 	HasPicoPlus    bool
+	HttpPass       bool
 }
 
 func hasProtocol(url string) bool {
@@ -289,6 +290,17 @@ func (h *ApiAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(hdr.Name, hdr.Value)
 		}
 	}
+
+	// Password-protected (http-pass) projects must never be stored in the
+	// shared cache. Our cache keys on subdomain+method+uri with no auth
+	// component, so a single authenticated request would populate the cache
+	// and let subsequent unauthenticated visitors bypass the password gate
+	// entirely. Force the response to be non-cacheable, overriding any
+	// user-supplied _headers cache-control.
+	if h.HttpPass {
+		w.Header().Set("cache-control", "private, no-store")
+	}
+
 	if w.Header().Get("content-type") == "" {
 		w.Header().Set("content-type", contentType)
 	}

--- a/pkg/apps/pgs/web_test.go
+++ b/pkg/apps/pgs/web_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	pgsdb "github.com/picosh/pico/pkg/apps/pgs/db"
+	"github.com/picosh/pico/pkg/db"
 	"github.com/picosh/pico/pkg/send/utils"
 	"github.com/picosh/pico/pkg/shared"
 	"github.com/picosh/pico/pkg/shared/mime"
@@ -471,6 +472,72 @@ func TestApiBasic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestApiHttpPassNotCached verifies that responses for password-protected
+// (http-pass) projects are served with `cache-control: private, no-store` so
+// the shared cache never stores them. Without this, the first authenticated
+// request would populate the cache and let later unauthenticated visitors
+// bypass the password gate. The asset here ships a `_headers` file that tries
+// to mark the response aggressively cacheable, to prove the http-pass override
+// wins over user-supplied headers.
+func TestApiHttpPassNotCached(t *testing.T) {
+	logger := slog.Default()
+	dbpool := NewPgsDb(logger)
+	user := dbpool.Users[0]
+	bucketName := shared.GetAssetBucketName(user.ID)
+
+	projectID, err := dbpool.InsertProject(user.ID, "secret", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := dbpool.FindProjectByName(user.ID, "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	project.Acl = db.ProjectAcl{Type: "http-pass", Data: []string{"hunter2"}}
+
+	store := map[string]map[string]string{
+		bucketName: {
+			"/secret/index.html": "top secret!",
+			"/secret/_headers":   "/*\n\tcache-control: public, max-age=31536000, immutable",
+		},
+	}
+
+	memSt, err := storage.NewStorageMemory(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := newTestStorage(memSt)
+	pubsub := NewPubsubChan()
+	defer func() {
+		_ = pubsub.Close()
+	}()
+	cfg := NewPgsConfig(logger, dbpool, st, pubsub)
+	cfg.Domain = "pgs.test"
+	router := NewWebRouter(cfg)
+
+	url := fmt.Sprintf("https://%s-secret.pgs.test/", user.Name)
+	request := httptest.NewRequest("GET", url, strings.NewReader(""))
+	// Supply a valid session cookie so we get past the password gate and
+	// actually serve the protected asset (the path we need to not cache).
+	request.AddCookie(&http.Cookie{
+		Name:  getCookieName("secret"),
+		Value: projectID,
+	})
+	responseRecorder := httptest.NewRecorder()
+	router.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("Want status '%d', got '%d'", http.StatusOK, responseRecorder.Code)
+	}
+	if body := strings.TrimSpace(responseRecorder.Body.String()); body != "top secret!" {
+		t.Fatalf("Want body 'top secret!', got '%s'", body)
+	}
+	cc := responseRecorder.Header().Get("cache-control")
+	if cc != "private, no-store" {
+		t.Errorf("http-pass response must be non-cacheable; want 'private, no-store', got '%s'", cc)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes #217 — password-protected (`http-pass`) `pgs` sites are readable without the password because the shared cache stores and replays the protected response to unauthenticated visitors.

## Why

The cache (`pkg/httpcache`) keys entries on `subdomain + method + uri` with no auth component, and only declines to store responses marked `private`/`no-store`. `http-pass` assets were served as `200` with `cache-control: max-age=60, s-maxage=600, must-revalidate` — which is storable. So the first authenticated request populated the cache, and every subsequent unauthenticated visitor got a cache hit that bypassed the cookie check (`web.go`) for the duration of the TTL.

## Change

- `ApiAssetHandler` gets an `HttpPass` flag, set from `project.Acl.Type == "http-pass"` in `ServeAsset`.
- When `HttpPass` is set, the handler forces `Cache-Control: private, no-store`, applied **after** the user `_headers` are merged so a project's own cache-control can't re-enable caching of protected content. `isResponseCachable` then refuses to store the response.

## Test

Adds `TestApiHttpPassNotCached`: serves an `http-pass` asset that ships a `_headers` file requesting `public, max-age=31536000, immutable`, and asserts the response goes out as `private, no-store`. Verified it fails on `main` (serves the aggressively-cacheable header) and passes with the fix.

```
ok  	github.com/picosh/pico/pkg/apps/pgs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
